### PR TITLE
Avoid building errors with some compilers

### DIFF
--- a/lib/component/NumberInput_Internal.js
+++ b/lib/component/NumberInput_Internal.js
@@ -13,7 +13,7 @@ function inputSetValue(input,value){
     input.dispatchEvent(new Event('input'));
 }
 
-NumberInput_Internal = function (stepValue, dp, onBegin, onChange, onFinish, onError) {
+function NumberInput_Internal(stepValue, dp, onBegin, onChange, onFinish, onError) {
     EventDispatcher.apply(this, null);
 
     this._value = 0;

--- a/lib/component/StringOutput.js
+++ b/lib/component/StringOutput.js
@@ -1,6 +1,6 @@
 var Output = require('./Output');
 
-StringOutput = function (parent, object, value, params) {
+function StringOutput(parent, object, value, params) {
     Output.apply(this, arguments);
 };
 StringOutput.prototype = Object.create(Output.prototype);


### PR DESCRIPTION
Theses two functions were not written using the coding standard
I was getting compilation errors with Webpack 2 and Babel