### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Object properties can be modified with basic control components including button
 [Usage](#usage) — [Setup](#setup) — [Panel](#panel) — [Container](#container) — [Component](#component) — [Styling](#styling) — [Alternatives](#alternatives) —
 [Dependencies](#dependencies) — [ChangeLog](#changeLog) — [License](#license)
 ___
-##Usage
+## Usage
 
 When using node or browserify install
 
@@ -27,9 +27,9 @@ or
     <script type='text/javascript' src='controlKit.min.js'></script>
    
 ___
-##Setup
+## Setup
 
-####new ControlKit(options) -> {ControlKit}
+#### new ControlKit(options) -> {ControlKit}
 
 The first step in using ControlKit is to create a new instance with some 
 optional customisations. The instance created will serve as a root element
@@ -44,17 +44,17 @@ opacity, styling ...
 | useExternalStyle | Boolean | If true, an external style is used instead of the build-in one, default: false |
 | history   | Boolean  | (Experimental) Enables a value history for all components, default: false |
 
-####controlKit.setShortcutEnable(char) -> {void}
+#### controlKit.setShortcutEnable(char) -> {void}
 
 Defines the char to be used with ctrl + char for enabling / disabling a ControlKit instance.
 
-####~~controlKit.registerKey(key,callback)~~
-####~~controlKit.getPanelById(id)->{Panel}~~
-####~~controlKit.getGroupById(id)->{Group}~~
-####~~controlKit.getSubGroupById(id)->{SubGroup}~~
-####~~controlKit.getComponentById(id)->{Component}~~
+#### ~~controlKit.registerKey(key,callback)~~
+#### ~~controlKit.getPanelById(id)->{Panel}~~
+#### ~~controlKit.getGroupById(id)->{Group}~~
+#### ~~controlKit.getSubGroupById(id)->{SubGroup}~~
+#### ~~controlKit.getComponentById(id)->{Component}~~
 
-###Structure
+### Structure
 
 There are two main elements of ControlKit: [containers](#container) and [components](*component*). The latter are constructed per panel and grouped in [Groups](#group) and [SubGroups](#subgroups) which root in [Panels](#panels). To keep the amount of code necessary to set up complex controls to a minimum, groups and components initialisation are chained to their parent panel.
 
@@ -78,13 +78,13 @@ There are two main elements of ControlKit: [containers](#container) and [compone
 	...
 
 ---
-##Container
+## Container
 
-###Panel
+### Panel
 
 The Panel is the main container element. It can either float to the left or right, be draggable or docked. It´s height can be adjusted to its groups or constrained to a certain height. Floated panels get stacked next to each other.
 
-####controlKit.addPanel(options) -> {[Panel](#panel)}
+#### controlKit.addPanel(options) -> {[Panel](#panel)}
 
 Adds a new Panel.
 
@@ -105,9 +105,9 @@ Adds a new Panel.
 | opacity   | Number   | Panel opacity                                     |
 | dock      | Boolean  | (Experimental) Indicates whether the panel should be docked to either the left or right window border (depending on params.align), docked panels height equal window height, default: false |
 
-###Group
+### Group
 
-####panel.addGroup(options)  
+#### panel.addGroup(options)  
 Adds a new Group to the Panel.
 
 **Options**
@@ -119,9 +119,9 @@ Adds a new Group to the Panel.
 | enable    | Boolean  | Defines initial state open / closed, default: true|
 | height    | Number   | Defines whether the height of the Group should be constrained to a certain height
 
-###SubGroup
+### SubGroup
 
-####panel.addSubGroup(options) ->{[Panel](#panel)}
+#### panel.addSubGroup(options) ->{[Panel](#panel)}
 
 Adds a new SubGroup to the last added Group.
 **Options**
@@ -161,7 +161,7 @@ Adds a new SubGroup to the last added Group.
         ...
     
 ---
-##Component
+## Component
 
 [explain linked components here]
 
@@ -180,9 +180,9 @@ Adds a new SubGroup to the last added Group.
 		.addNumberInput(obj,'valueB')
 		.addFunctionPlotter(obj,'func');
 
-###Built-in components
+### Built-in components
 
-####General advice!
+#### General advice!
 
 All number related components including sliders have an option for specifying the
 amount of decimal places. To prevent weird behaviour when updating an objects number property
@@ -192,7 +192,7 @@ the same amount of decimal places in every component modifying the same property
 
 ![NumberInput](images/NumberInput.png)<br/>
 ![NumberInputOption](images/NumberInputOption.png)
-####panel.addNumberInput(object,propertyKey,options) -> {[Panel](#panel)}
+#### panel.addNumberInput(object,propertyKey,options) -> {[Panel](#panel)}
     
 Adds a new NumberInput to the last added SubGroup. Returns panel.  
 **Options**
@@ -207,7 +207,7 @@ Adds a new NumberInput to the last added SubGroup. Returns panel.
 
 
 ![NumberOutput](images/NumberOutput.png)
-####panel.addNumberOutput(object,propertyKey,options) -> {[Panel](#panel)}
+#### panel.addNumberOutput(object,propertyKey,options) -> {[Panel](#panel)}
 
 Adds a new NumberOutput to the last added SubGroup. In contrast to NumberInput this component doesn't allow modifying the property.  
 **Options**
@@ -220,7 +220,7 @@ Adds a new NumberOutput to the last added SubGroup. In contrast to NumberInput t
 
 ![StringInput](images/StringInput.png)<br/>
 ![StringInputOption](images/StringInputOption.png)
-####panel.addStringInput(object,propertyKey,options) -> {[Panel](#panel)}
+#### panel.addStringInput(object,propertyKey,options) -> {[Panel](#panel)}
 
 Adds a new StringInput to the last added SubGroup.  
 **Options**
@@ -233,7 +233,7 @@ Adds a new StringInput to the last added SubGroup.
 
 
 ![StringOutput](images/StringOutput.png)
-####panel.addStringOutput(object,propertyKey,options) -> {[Panel](#panel)}
+#### panel.addStringOutput(object,propertyKey,options) -> {[Panel](#panel)}
 
 Adds a new StringOutput to the last added SubGroup. In contrast to StringInput this component doesn't allow modifying the property.  
 **Options**
@@ -244,7 +244,7 @@ Adds a new StringOutput to the last added SubGroup. In contrast to StringInput t
 
 
 ![Slider](images/Slider.png)
-####panel.addSlider(object,propertyKey,rangeKey,options) -> {[Panel](#panel)}
+#### panel.addSlider(object,propertyKey,rangeKey,options) -> {[Panel](#panel)}
 
 Adds a new Slider to the last added SubGroup.
 
@@ -263,7 +263,7 @@ Adds a new Slider to the last added SubGroup.
 
 
 ![Range](images/Range.png)
-####panel.addRange(object,propertyKey,options) -> {[Panel](#panel)}
+#### panel.addRange(object,propertyKey,options) -> {[Panel](#panel)}
 
 Adds a new Checkbox to the last added SubGroup.
 **Options**
@@ -275,7 +275,7 @@ Adds a new Checkbox to the last added SubGroup.
 
 
 ![Button](images/Button.png)
-####panel.addButton(label,onPress,options) -> {[Panel](#panel)}
+#### panel.addButton(label,onPress,options) -> {[Panel](#panel)}
 
 Adds a new Button to the last added SubGroup.
 
@@ -288,7 +288,7 @@ Adds a new Button to the last added SubGroup.
 
 
 ![Checkbox](images/Checkbox.png)
-####panel.addCheckbox(object,propertyKey,options) -> {[Panel](#panel)}
+#### panel.addCheckbox(object,propertyKey,options) -> {[Panel](#panel)}
 
 Adds a new Checkbox to the last added SubGroup.
 **Options**
@@ -301,7 +301,7 @@ Adds a new Checkbox to the last added SubGroup.
 
 ![Select](images/Select.png)<br/>
 ![SelectOption](images/SelectOption.png)
-####panel.addSelect(object,propertyKey,options) -> {[Panel](#panel)}
+#### panel.addSelect(object,propertyKey,options) -> {[Panel](#panel)}
 
 Adds a new Select to the last added SubGroup.
 
@@ -335,7 +335,7 @@ Adds a new Select to the last added SubGroup.
 ![Color](images/Color.png)<br/>
 ![ColorOption](images/ColorOption.png)<br/>
 ![Picker](images/ColorPicker.png)
-####panel.addColor(object,propertyKey,options) -> {[Panel](#panel)}
+#### panel.addColor(object,propertyKey,options) -> {[Panel](#panel)}
 
 Adds a new Color modifier to the last added SubGroup.
 
@@ -354,7 +354,7 @@ Adds a new Color modifier to the last added SubGroup.
 
 
 ![Pad](images/Pad.png)
-####panel.addPad(object,propertyKey,options) -> {[Panel](#panel)}
+#### panel.addPad(object,propertyKey,options) -> {[Panel](#panel)}
 
 Adds a new XY-Pad to the last added SubGroup.
 **Options**
@@ -365,7 +365,7 @@ Adds a new XY-Pad to the last added SubGroup.
 
 
 ![FunctionPlotter](images/FunctionPlotter.png)
-####panel.addFunctionPlotter(object,propertyKey,options) -> {[Panel](#panel)}
+#### panel.addFunctionPlotter(object,propertyKey,options) -> {[Panel](#panel)}
 
 Adds a new FunctionPlotter to the last added SubGroup.
 **Options**
@@ -377,7 +377,7 @@ Adds a new FunctionPlotter to the last added SubGroup.
 | lineColor | Array    | Graph line color [255,255,255]                    | 
 
 ![ValuePlotter](images/ValuePlotter.png)
-####panel.addValuePlotter(object,propertyKey,options) -> {[Panel](#panel)}
+#### panel.addValuePlotter(object,propertyKey,options) -> {[Panel](#panel)}
 
 Adds a new ValuePlotter to the last added SubGroup.
 **Options**
@@ -391,13 +391,13 @@ Adds a new ValuePlotter to the last added SubGroup.
 | lineColor | Array    | Graph line color [255,255,255]                    |            
 
 
-###Custom Components
+### Custom Components
 
-####~~Custom Canvas Component~~ 
-####~~Custom SVG Component~~ 
+#### ~~Custom Canvas Component~~ 
+#### ~~Custom SVG Component~~ 
 
 
-###Sync to external change
+### Sync to external change
 
 If a value gets changed externally, eg in an update loop, you can sync ControlKit by using:
 *(be aware that this might have a quite huge performance impact when using complex control setups)*
@@ -407,7 +407,7 @@ If a value gets changed externally, eg in an update loop, you can sync ControlKi
 	}
   
 ---
-##Styling
+## Styling
 
 If the default styling is too photoshoppy for your taste, you can completly replace it by modifying the default one located in [./style](../master/style/).  
 
@@ -428,20 +428,20 @@ If for some reason, you want to *completly replace* the default styling. Alter i
 This will inject the new default style into to the packaged version controlKit.js and controlKit.min.js within ./bin, but will also completly replace the default module version.
 
 ---
-##Alternatives
+## Alternatives
 
 [dat.gui](https://github.com/dataarts/dat.gui) — The de facto standard    
 [Palette](https://github.com/lehni/palette.js) — Juerg Lehni  
 [Guido](https://github.com/fjenett/Guido) — Processing.js compatible, Florian Jenett
 
 
-##DevDepencies   
+## DevDepencies   
 [browserify](https://github.com/substack/node-browserify)  
 [uglify-js](https://github.com/mishoo/UglifyJS2)
 [clean-css](https://github.com/jakubpawlowicz/clean-css)
 
 
-##License
+## License
 
 The MIT License (MIT)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
