### PR TITLE
fix (disposing) 'destroy'` is a static method

### DIFF
--- a/lib/ControlKit.js
+++ b/lib/ControlKit.js
@@ -307,9 +307,9 @@ ControlKit.prototype.getNode = function () {
 };
 
 ControlKit.destroy = function(){
-    Mouse.get().destroy();
-    Options.get().destroy();
-    Picker.get().destroy();
+    Mouse.destroy();
+    Options.destroy();
+    Picker.destroy();
     initiated = false;
 };
 


### PR DESCRIPTION
It looks like a typo. Each component exports the `destroy` function as a static method, not the `instance` method.