### PR TITLE
ColorPicker real time onChange

### DIFF
--- a/lib/component/Picker.js
+++ b/lib/component/Picker.js
@@ -623,6 +623,7 @@ Picker.prototype =
 
         var onDrag = function () {
                 self._drawHandleField();
+                self._callbackPick();
             },
             onDragEnd = function () {
                 document.removeEventListener(eventMouseMove, onDrag, false);


### PR DESCRIPTION
This will automatically call the onChange() handler when moving the mouse over the color picker.
Fix #50 