### PR TITLE
trigger onChange for preset values in StringInput

### DIFF
--- a/lib/component/StringInput.js
+++ b/lib/component/StringInput.js
@@ -53,6 +53,7 @@ function StringInput(parent,object,value,params) {
                     input.setProperty('value', presets[options.getSelectedIndex()]);
                     self.pushHistoryState();
                     self.applyValue();
+                    self._onChange();
                 },
                 onPresetDeactivate,
                 Metric.PADDING_PRESET,


### PR DESCRIPTION
fix minor bug:
when i click a preset value
i must press enter to trigger the onChange event